### PR TITLE
build: add Maven Central publishing

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("software.sava.gradle.feature.publish-maven-central")
+}
+
+dependencies {
+  nmcpAggregation(project(":sava-core"))
+  nmcpAggregation(project(":sava-rpc"))
+}

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -7,6 +7,7 @@ repositories {
 }
 
 dependencies {
+  implementation("com.gradleup.nmcp:nmcp:0.1.5")
   implementation("com.github.iherasymenko.jlink:jlink-plugin:0.7")
   implementation("com.gradle:develocity-gradle-plugin:4.0.2")
 }

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.build.settings.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.build.settings.gradle.kts
@@ -10,3 +10,6 @@ gradle.lifecycle.beforeProject {
     apply(plugin = "software.sava.gradle.java-module")
   }
 }
+
+include(":aggregation")
+project(":aggregation").projectDir = file("gradle/aggregation")

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.feature.publish-maven-central.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.feature.publish-maven-central.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+  id("maven-publish")
+  id("com.gradleup.nmcp.aggregation")
+}
+
+nmcpAggregation {
+  centralPortal {
+    username = providers.environmentVariable("MAVEN_CENTRAL_USERNAME")
+    password = providers.environmentVariable("MAVEN_CENTRAL_PASSWORD")
+    publishingType = "USER_MANAGED" // "AUTOMATIC"
+  }
+}

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.feature.publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.feature.publish.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("java")
   id("maven-publish")
   id("signing")
+  id("com.gradleup.nmcp")
 }
 
 val gprUser =


### PR DESCRIPTION
Support publishing to Maven Central via new mechanism.

This does the config on the Gradle side. In GitHub actions:

- Keep `:core:publish :rpc:publish` to publish to GH packages
- Add `publishAggregationToCentralPortal` to publish to Maven Central